### PR TITLE
Epic 14: Complete combinators __init__.py with all migrated combinators

### DIFF
--- a/.claude/FLOW_ENGINE_MIGRATION_PLAN.md
+++ b/.claude/FLOW_ENGINE_MIGRATION_PLAN.md
@@ -125,10 +125,11 @@ The Flow Engine will be extracted as `flowengine` - a **separate package** that:
 - Dependencies: `flowengine.flow`, `flowengine.combinators.basic`
 - **Status**: Complete (10 functions migrated, all refactored to ≤15 lines)
 
-**Epic 14: Complete combinators __init__.py**
+**~Epic 14: Complete combinators __init__.py~ ✅ DONE!**
 - File: `src/flowengine/combinators/__init__.py` (complete)
 - Source: `old/goldentooth_agent/flow_engine/combinators/__init__.py` (171 lines)
 - Export all combinators
+- **Result**: All 65 combinators exported across 8 categories, comprehensive public API complete
 
 ## Phase 3: Observability System (Epics 15-22)
 

--- a/.claude/retros/epic-14-combinators-init.md
+++ b/.claude/retros/epic-14-combinators-init.md
@@ -1,0 +1,154 @@
+# Epic 14: Complete Combinators __init__.py - Retrospective
+
+## Overview
+Epic 14 involved completing the `src/flowengine/combinators/__init__.py` file to export all migrated combinators from previous epics (Epics 5-13), creating a comprehensive public API for the combinators package.
+
+## What Went Well
+
+### 1. Systematic Export Organization
+- Successfully identified all migrated combinator categories
+- Organized imports and exports by logical groupings:
+  - Utils (2 functions from Epic 5)
+  - Sources (4 functions from Epic 6)
+  - Basic (13 functions from Epic 7)
+  - Aggregation (11 functions from Epic 9)
+  - Temporal (5 functions from Epic 10)
+  - Control flow (11 functions from Epic 12)
+  - Observability (9 exports from Epic 11: 5 functions + 4 classes)
+  - Advanced (10 functions from Epic 13)
+
+### 2. Import Verification Process
+- Methodically compared current vs. old __init__.py files
+- Identified missing aggregation and temporal exports immediately
+- Caught and fixed import errors (window_time_stream not existing)
+
+### 3. Documentation Updates
+- Enhanced module docstring to reflect all combinator categories
+- Added clear descriptions for aggregation and temporal categories
+- Maintained consistency with existing documentation style
+
+### 4. Quality Assurance
+- Verified all imports work correctly with comprehensive testing
+- Confirmed total export count matches expectations (65 functions/classes)
+- Ensured existing tests continue to pass (255 tests passed)
+
+## Challenges Encountered
+
+### 1. Import Error Detection
+- Initially included `window_time_stream` which doesn't exist in temporal module
+- Had to debug import errors and verify actual function names
+- Required checking actual module contents vs. expected imports
+
+### 2. Function Count Verification
+- Needed to carefully count exports across categories
+- Temporal had 5 functions, not 6 as initially assumed
+- Required verification that all promised functions from previous epics were included
+
+## Lessons Learned
+
+### 1. Always Verify Against Source
+- Don't assume function names without checking the actual modules
+- Use grep/search to verify function definitions exist
+- Import testing catches issues early
+
+### 2. Documentation Must Match Reality
+- Module docstrings should accurately reflect available functionality
+- Comments about function counts must be accurate
+- Regular verification prevents documentation drift
+
+### 3. Systematic Testing Pays Off
+- Running imports after each change catches issues immediately
+- Testing by category helps isolate problems
+- Comprehensive testing builds confidence
+
+## Technical Implementation
+
+### Export Structure
+```python
+# Total: 65 exports across 8 categories
+__all__ = [
+    # Utils (2 functions)
+    "get_function_name", "create_single_item_stream",
+
+    # Sources (4 functions)
+    "range_flow", "repeat_flow", "empty_flow", "start_with_stream",
+
+    # Basic combinators (13 functions)
+    # ... complete list organized by category
+
+    # Aggregation combinators (11 functions)
+    # Temporal combinators (5 functions)
+    # Control flow combinators (11 functions)
+    # Observability combinators (9 exports)
+    # Advanced combinators (10 functions)
+]
+```
+
+### Import Organization
+- Grouped imports by combinator category
+- Added clear comments indicating epic numbers and function counts
+- Maintained alphabetical ordering within categories
+
+## Metrics
+
+- **Total Exports**: 65 functions and classes
+- **Modules Integrated**: 7 combinator modules
+- **Categories Represented**: 8 distinct categories
+- **Test Coverage**: All exports verified through comprehensive testing
+- **Time Spent**: ~30 minutes (quick epic focused on integration)
+
+## Validation Results
+
+### Import Testing
+```bash
+✅ All combinator imports successful
+✅ Total functions in __all__: 65
+✅ Expected vs actual count: Perfect match
+✅ All 255 combinator tests passing
+```
+
+### Coverage by Category
+- Utils: 100% (2/2 functions exported)
+- Sources: 100% (4/4 functions exported)
+- Basic: 100% (13/13 functions exported)
+- Aggregation: 100% (11/11 functions exported)
+- Temporal: 100% (5/5 functions exported)
+- Control Flow: 100% (11/11 functions exported)
+- Observability: 100% (9/9 exports)
+- Advanced: 100% (10/10 functions exported)
+
+## Dependencies Satisfied
+
+This epic completes the public API for the combinators package, providing access to all functionality migrated in previous epics:
+
+1. ✅ Epic 5: Utils (get_function_name, create_single_item_stream)
+2. ✅ Epic 6: Sources (range_flow, repeat_flow, empty_flow, start_with_stream)
+3. ✅ Epic 7: Basic combinators (13 functions)
+4. ✅ Epic 9: Aggregation combinators (11 functions)
+5. ✅ Epic 10: Temporal combinators (5 functions)
+6. ✅ Epic 11: Observability combinators (5 functions + 4 classes)
+7. ✅ Epic 12: Control flow combinators (11 functions)
+8. ✅ Epic 13: Advanced combinators (10 functions)
+
+## Future Considerations
+
+### 1. Module Structure
+- Current single __init__.py works well for now
+- May consider sub-module imports if categories grow significantly
+- Keep monitoring for 1000-line limit
+
+### 2. Documentation
+- Could add usage examples to module docstring
+- Consider creating category-specific documentation
+- Maintain as more combinators are added
+
+### 3. Testing
+- Current import testing is adequate
+- Could add explicit testing of __all__ completeness
+- Consider integration tests using the full public API
+
+## Conclusion
+
+Epic 14 was a straightforward integration epic that successfully unified all previously migrated combinators into a coherent public API. The systematic approach to verification and testing ensured a reliable result with comprehensive coverage of all migrated functionality.
+
+The completed combinators package now provides a clean, well-organized interface to 65 functions and classes across 8 categories, maintaining the high-quality standards established in previous epics.

--- a/src/flowengine/combinators/__init__.py
+++ b/src/flowengine/combinators/__init__.py
@@ -3,6 +3,8 @@
 This module provides essential building blocks for creating and composing flows:
 
 - **Basic combinators**: Core operations like map, filter, compose, etc.
+- **Aggregation combinators**: Batching, grouping, scanning, and windowing operations
+- **Temporal combinators**: Time-based operations like debounce, throttle, and delay
 - **Control flow combinators**: Conditional processing, error handling, and flow control
 - **Source flows**: Functions that create streams from various inputs
 - **Observability combinators**: Functions for logging, tracing, and monitoring streams
@@ -24,6 +26,21 @@ from .advanced import (
     parallel_stream_successful,
     race_stream,
     zip_stream,
+)
+
+# Aggregation combinators (11 functions migrated in Epic 9)
+from .aggregation import (
+    batch_stream,
+    buffer_stream,
+    chunk_stream,
+    distinct_stream,
+    expand_stream,
+    finalize_stream,
+    group_by_stream,
+    memoize_stream,
+    pairwise_stream,
+    scan_stream,
+    window_stream,
 )
 
 # Basic combinators (13 functions migrated in Epic 7)
@@ -71,17 +88,26 @@ from .observability import (
     trace_stream,
 )
 
-# Sources
+# Sources (4 functions migrated in Epic 6)
 from .sources import empty_flow, range_flow, repeat_flow, start_with_stream
 
-# Utils
+# Temporal combinators (5 functions migrated in Epic 10)
+from .temporal import (
+    debounce_stream,
+    delay_stream,
+    sample_stream,
+    throttle_stream,
+    timeout_stream,
+)
+
+# Utils (2 functions migrated in Epic 5)
 from .utils import create_single_item_stream, get_function_name
 
 __all__ = [
-    # Utils
+    # Utils (2 functions)
     "get_function_name",
     "create_single_item_stream",
-    # Sources
+    # Sources (4 functions)
     "range_flow",
     "repeat_flow",
     "empty_flow",
@@ -100,6 +126,24 @@ __all__ = [
     "collect_stream",
     "until_stream",
     "share_stream",
+    # Aggregation combinators (11 functions)
+    "batch_stream",
+    "buffer_stream",
+    "chunk_stream",
+    "distinct_stream",
+    "expand_stream",
+    "finalize_stream",
+    "group_by_stream",
+    "memoize_stream",
+    "pairwise_stream",
+    "scan_stream",
+    "window_stream",
+    # Temporal combinators (5 functions)
+    "debounce_stream",
+    "delay_stream",
+    "sample_stream",
+    "throttle_stream",
+    "timeout_stream",
     # Control flow combinators (11 functions)
     "if_then_stream",
     "retry_stream",
@@ -112,7 +156,7 @@ __all__ = [
     "circuit_breaker_stream",
     "chain_flows",
     "branch_flows",
-    # Observability combinators (5 functions + 3 notification classes)
+    # Observability combinators (5 functions + 4 classes)
     "log_stream",
     "trace_stream",
     "metrics_stream",


### PR DESCRIPTION
## Summary
- Complete the combinators package __init__.py to export all migrated combinators from Epics 5-13
- Fix missing aggregation and temporal combinator exports
- Organize 65 total exports across 8 categories with comprehensive public API

## Test plan
- [x] All combinator imports verified working
- [x] 255 combinator tests passing  
- [x] Pre-commit hooks passing
- [x] Export count verified (65 functions/classes)
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)