### PR TITLE
Epic 22: Create observability health exports

### DIFF
--- a/.claude/FLOW_ENGINE_MIGRATION_PLAN.md
+++ b/.claude/FLOW_ENGINE_MIGRATION_PLAN.md
@@ -38,7 +38,7 @@ The Flow Engine will be extracted as `flowengine` - a **separate package** that:
 
 ## Phase 3: Observability System (Epics 15-31)
 
-### Epic 22: Create observability health exports
+### Epic 22: Create observability health exports ✅ DONE!
 **Unit**: Health monitoring exports
 **Source**: `old/goldentooth_agent/flow_engine/observability/__init__.py` (health section)
 **Target**: `src/flowengine/observability/__init__.py` (partial)

--- a/.claude/retros/epic-22-observability-health-exports.md
+++ b/.claude/retros/epic-22-observability-health-exports.md
@@ -1,0 +1,35 @@
+# Epic 22: Create observability health exports - Retrospective
+
+## Summary
+Updated the import structure in `src/flowengine/observability/__init__.py` to match the exact format specified in Epic 22 of the Flow Engine Migration Plan.
+
+## What Went Well
+- The health monitoring functionality was already fully implemented in the codebase
+- All required exports were available and working correctly
+- Tests were comprehensive and all passed without modification
+- The change was minimal and focused - only import structure needed updating
+
+## What Was Challenging
+- Initial investigation showed the exports already existed but in a different format
+- Had to determine whether the current implementation satisfied Epic 22 or needed adjustment
+- Pre-commit hooks (isort) reordered imports after initial changes
+
+## Key Learnings
+1. The Flow Engine migration has been progressing well - much of the health monitoring system was already migrated
+2. The migration plan is very specific about import structure, requiring exact module paths even when re-exports exist
+3. Always run pre-commit hooks before committing to avoid commit failures
+
+## Technical Details
+- Changed from importing everything from `.health` to explicit imports from:
+  - `.health.core` for core types (HealthStatus, HealthCheck, etc.)
+  - `.health.checks` for FlowHealthMonitor and check functions
+  - `.health.reporting` for reporting and utility functions
+- The change maintains backward compatibility as all exports remain in the same locations
+
+## Follow-up Items
+None - Epic 22 is complete and all tests pass.
+
+## Metrics
+- Lines changed: ~30 (import statements only)
+- Tests affected: 0 (all existing tests continued to pass)
+- Time to complete: ~15 minutes

--- a/src/flowengine/observability/__init__.py
+++ b/src/flowengine/observability/__init__.py
@@ -34,15 +34,8 @@ from .debugging import (
     remove_flow_breakpoint,
     traced_flow,
 )
-
-# Health monitoring exports
-from .health import (  # Core health types; Health monitoring; Configuration validation; Built-in health checks; Convenience functions
-    FlowConfigValidator,
+from .health.checks import (
     FlowHealthMonitor,
-    HealthCheck,
-    HealthCheckResult,
-    HealthStatus,
-    SystemHealth,
     check_flow_configuration,
     check_flow_dependencies,
     check_flow_errors,
@@ -50,8 +43,14 @@ from .health import (  # Core health types; Health monitoring; Configuration val
     check_flow_responsiveness,
     check_memory_usage,
     check_resource_limits,
-    check_system_health,
     check_system_resources,
+)
+
+# Health monitoring
+from .health.core import HealthCheck, HealthCheckResult, HealthStatus, SystemHealth
+from .health.reporting import (
+    FlowConfigValidator,
+    check_system_health,
     export_health_report,
     get_config_validator,
     get_health_monitor,


### PR DESCRIPTION
## Summary
- Update observability health exports to match Epic 22 specifications
- Restructure imports to show exact sub-module paths as required by migration plan
- Mark Epic 22 as complete in the Flow Engine Migration Plan

## Details
This PR completes Epic 22 of the Flow Engine Migration Plan by updating the import structure in `src/flowengine/observability/__init__.py`. The health monitoring functionality was already fully implemented, but the imports needed to be restructured to match the exact format specified in the migration plan:

- Import core health types from `.health.core`
- Import `FlowHealthMonitor` and check functions from `.health.checks`
- Import reporting functions from `.health.reporting`

## Test plan
- [x] All existing health monitoring tests continue to pass
- [x] Import verification confirms all exports are accessible
- [x] Pre-commit hooks pass (black, isort, ruff, mypy, pyright)
- [x] No functionality changes - only import structure updated

🤖 Generated with [Claude Code](https://claude.ai/code)