### PR TITLE
Add pre-commit hook to prevent commits to main branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,8 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
       - id: check-docstring-first
+      - id: no-commit-to-branch
+        args: [--branch, main]
 
   # Local hooks using our dev dependencies
   - repo: local


### PR DESCRIPTION
## Summary
• Added `no-commit-to-branch` hook to prevent accidental commits to main branch
• Enforces proper branch-based development workflow
• Hook automatically runs during pre-commit to catch attempts to commit to main

## Test plan
- [x] Verified hook is properly configured in `.pre-commit-config.yaml`
- [x] Tested hook execution with `uv run pre-commit run no-commit-to-branch --all-files`
- [x] Confirmed hook passes when not on main branch

🤖 Generated with [Claude Code](https://claude.ai/code)